### PR TITLE
Bugfix - initially hidden feature wasn't working

### DIFF
--- a/resources/views/password.blade.php
+++ b/resources/views/password.blade.php
@@ -14,6 +14,7 @@
     $suffixIcon = $getSuffixIcon();
     $suffixLabel = $getSuffixLabel();
     $statePath = $getStatePath();
+    $initiallyHidden = $isInitiallyHidden() ? 'true' : 'false';
 
 $stylecode = '';
     $x = 0;
@@ -65,7 +66,7 @@ $stylecode = '';
                     }
                 $copyPassword .= '}';
 
-    $xdata = '{ show: true,
+    $xdata = '{ show: ' . $initiallyHidden . ',
             isRtl: false,
             generatePasswd: function() {
 


### PR DESCRIPTION
->initiallyHidden was ignored, this restores previous behavior where setting it to false would show the password field contents during load.